### PR TITLE
Fixed typo in api.takeControl

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -407,7 +407,7 @@
 		}
 
 		takeControl(password) {
-			if (!_.isUndefined(pass) && !_.isString(password))
+			if (!_.isUndefined(password) && !_.isString(password))
 				throw new TypeError('Password must be a string');
 
 			return this.send(Command.takeControl(password));


### PR DESCRIPTION
This typo stopped api.takeControl from working correctly. This typo fixes takeControl and now works properly.